### PR TITLE
Simplify send state

### DIFF
--- a/lib/response_state/service.rb
+++ b/lib/response_state/service.rb
@@ -17,9 +17,8 @@ module ResponseState
       fail NotImplementedError, "A ResponseState::Service should implement the call method.\nThe call method should perform the relevant work of the service and yield a ResponseState::Response object.\n"
     end
 
-    def send_state(state, message=nil, context=nil, valid_states=nil)
-      valid_states ||= self.class.valid_states
-      ResponseState::Response.new(state, message, context, valid_states)
+    def send_state(state, message=nil, context=nil)
+      ResponseState::Response.new(state, message, context, self.class.valid_states)
     end
   end
 end

--- a/spec/lib/response_state/service_spec.rb
+++ b/spec/lib/response_state/service_spec.rb
@@ -35,26 +35,6 @@ module ResponseState
     end
 
     describe '#send_state' do
-      context 'given :success, "a message", {}, [:success, :failure]' do
-        let(:response) { service.send_state(:success, 'a message', {}, [:success, :failure]) }
-
-        it 'has a success state' do
-          expect(response.state).to eq :success
-        end
-
-        it 'has the message "a message"' do
-          expect(response.message).to eq 'a message'
-        end
-
-        it 'has the context {}' do
-          expect(response.context).to eq Hash.new
-        end
-
-        it 'has valid_states [:success, :failure]' do
-          expect(response.valid_states).to eq [:success, :failure]
-        end
-      end
-
       context 'given :success, "a message", {}' do
         let(:response) { service.send_state(:success, 'a message', {}) }
         before { Service.response_states :success, :failure }


### PR DESCRIPTION
The 4th argument to send_state wasn't documented and I can't see it ever being used.
The class should set its response states and overriding them when sending a particular state seems wrong.
