### PR TITLE
Implicit yield

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ class MyService < ResponseState::Service
 
   def call(&block)
     # do some work
-    yield send_state :success
+    send_state :success
   end
 end
 ```
 
 You must implement a `call` method.
 
-Your call method should yield with a call to `send_state` which will create a `ResponseState::Response`.
+Your call method should return a call to `send_state` which will create a `ResponseState::Response`.
 
 The `send_state` method takes at a minimum a symbol representing the state. It optionally can also
 take a message and a context. The message by convention should be a string but there are no restrictions.

--- a/lib/response_state/service.rb
+++ b/lib/response_state/service.rb
@@ -10,11 +10,15 @@ module ResponseState
     end
 
     def self.call(*args, &block)
-      self.new(*args).call(&block)
+      self.new(*args).yield_response_to(&block)
     end
 
-    def call(&block)
-      fail NotImplementedError, "A ResponseState::Service should implement the call method.\nThe call method should perform the relevant work of the service and yield a ResponseState::Response object.\n"
+    def yield_response_to(&block)
+      yield call
+    end
+
+    def call
+      fail NotImplementedError, "A ResponseState::Service should implement the call method.\nThe call method should perform the relevant work of the service and return a ResponseState::Response object.\n"
     end
 
     def send_state(state, message=nil, context=nil)

--- a/spec/features/full_example_spec.rb
+++ b/spec/features/full_example_spec.rb
@@ -10,7 +10,7 @@ class MyService < ResponseState::Service
   end
 
   def call
-    yield (success_response or failure_response)
+    success_response or failure_response
   end
 
   private

--- a/spec/lib/response_state/service_spec.rb
+++ b/spec/lib/response_state/service_spec.rb
@@ -10,8 +10,15 @@ module ResponseState
     end
 
     describe '.call' do
-      it 'news up an instance and passes the block on to #call' do
-        expect { |b| Service.(&b) }.to raise_error(NotImplementedError, "A ResponseState::Service should implement the call method.\nThe call method should perform the relevant work of the service and yield a ResponseState::Response object.\n")
+      let(:response) { double :response }
+
+      before do
+        allow(Service).to receive(:new).and_return(service)
+        allow(service).to receive(:call).and_return(response)
+      end
+
+      it 'news up an instance and passes the result of #call to the block' do
+        expect { |b| Service.(&b) }.to yield_with_args(response)
       end
     end
 
@@ -30,7 +37,7 @@ module ResponseState
 
     describe '#call' do
       it 'raises an error' do
-        expect { service.call }.to raise_error(NotImplementedError, "A ResponseState::Service should implement the call method.\nThe call method should perform the relevant work of the service and yield a ResponseState::Response object.\n")
+        expect { service.call }.to raise_error(NotImplementedError, "A ResponseState::Service should implement the call method.\nThe call method should perform the relevant work of the service and return a ResponseState::Response object.\n")
       end
     end
 


### PR DESCRIPTION
Couple ideas that came out of this.
1. Is it worth throwing an error if `call` does not return a `ResponseState::Response`?
2. Does `call` really need to return a response? As long as send_data is called we have what we need
   - could yield to the block inside send_data (which I think calls for renaming `send_data` to `respond`)
   - could save the response and yield it when `call` ends
   - would still expect users to make the call last but its just one less restriction
